### PR TITLE
# 0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.0.6
+
+* [FIX] Missing library dependency fix.
+* [IMP] Added optional `--local` flag. Lemmy won't run in non-PR builds by default.
+
 # 0.0.5
 
 * [FIX] Travis build fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lemmy",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Integrate Lemmy, and it will comment your PRs, answering a vital question \"Lemme know what's going on my CI server\"",
   "main": "run.js",
   "repository": "git@github.com:krzysztof-miemiec/lemmy.git",
@@ -19,7 +19,6 @@
     "@types/node": "^9.4.0",
     "@types/request": "^2.47.0",
     "babel-cli": "^6.26.0",
-    "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "eslint": "^4.16.0",
     "eslint-config-airbnb-base": "^12.1.0",
@@ -29,6 +28,7 @@
     "typescript": "^2.7.1"
   },
   "dependencies": {
+    "babel-polyfill": "^6.26.0",
     "request": "^2.83.0"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,9 @@
 import { readFile } from './utils/promises';
 
 export interface Config {
+  args: {
+    local?: string;
+  };
   git: {
     baseBranch?: string;
     repo?: string;
@@ -23,7 +26,15 @@ const undefinedIfFalse = (value: string): string => value === 'false' ? undefine
 
 export const getConfig = async (configLocation: string = '.lemmy.json'): Promise<Config> => {
   const file = await readFile(configLocation, 'utf-8');
+  const args = {};
+  process.argv
+    .filter(arg => arg.startsWith('--'))
+    .forEach((arg) => {
+      const [key, value] = [...arg.split('='), ''];
+      args[key.replace(/^--/, '')] = value;
+    });
   const config: Config = {
+    args,
     git: {
       baseBranch: process.env.TRAVIS_BRANCH || 'master',
       repo: process.env.TRAVIS_REPO_SLUG,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,13 @@ const run = async () => {
   const context: Context = { config, message };
   const errors: string[] = [];
 
+  if (config.args.local === undefined && !config.git.pull) {
+    console.log('Skipping Lemmy actions, because PR identifier hasn\'t been found.' +
+      'Add `--local` flag in order to run Lemmy locally.');
+    process.exit(0);
+    return;
+  }
+
   for (const action of config.actions) {
     let module;
     try {


### PR DESCRIPTION
* [FIX] Missing library dependency fix.
* [IMP] Added optional `--local` flag. Lemmy won't run in non-PR builds by default.