### PR TITLE
Do not comment the same commit twice

### DIFF
--- a/.lemmy.json
+++ b/.lemmy.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "githubComment",
-      "oneCommentPerCommit": false
+      "oneCommentPerCommit": true
     },
     "stdout"
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.13
+
+* [FIX] Do not comment the same commit twice when the last Lemmy comment isn't about the commit.
+
 # 0.0.12
 
 * [FIX] Fixed issues with env vars not passed to git properly

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lemmy",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Integrate Lemmy, and it will comment your PRs, answering a vital question \"Lemme know what's going on my CI server\"",
   "main": "run.js",
   "repository": "git@github.com:krzysztof-miemiec/lemmy.git",

--- a/src/actions/githubComment.ts
+++ b/src/actions/githubComment.ts
@@ -64,13 +64,12 @@ Please add environmental variable GITHUB_TOKEN to your CI or a local machine.`);
     const comments = await get(commentsUrl, requestOptions);
     const myComments = comments.body.filter(comment => comment.user.id === userId);
     let skipComment = false;
-    if (myComments.length > 0) {
-      const commentBody = myComments[myComments.length - 1].body;
-      const commitMatch = commentBody.match(/^:octocat: Commit\s*\|\s*(.+)\s*$/m);
+    myComments.forEach((comment) => {
+      const commitMatch = comment.body.match(/^:octocat: Commit\s*\|\s*(.+)\s*$/m);
       if (commitMatch && commitMatch[1] === commit) {
-        skipComment = params.oneCommentPerCommit;
+        skipComment = skipComment || params.oneCommentPerCommit;
       }
-    }
+    });
 
     // Post comment!
     if (!skipComment) {


### PR DESCRIPTION
* [FIX] Do not comment the same commit twice when the last Lemmy comment isn't about the commit.